### PR TITLE
Move registering of plugins and endpoints

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,17 +18,17 @@ const app = fastify({
   logger: true
 });
 
+// Initialize plugins
+app.register(utility);
+app.register(database);
+app.register(middleware);
+
+// Register endpoints
+app.register(userCreate);
+app.register(userDetails);
+
 // Asynchronous tasks
 (async () => {
-
-  // Initialize plugins
-  app.register(utility);
-  app.register(database);
-  app.register(middleware);
-
-  // Register endpoints
-  app.register(userCreate);
-  app.register(userDetails);
 
   // Run the webserver
   await app.listen(process.env.PORT);


### PR DESCRIPTION
## Summary
- Code which registered plugins and endpoints was unnecessarily located in an anonymous async function, I moved it outside of that function.

Resolves #41 
